### PR TITLE
Refactor 2

### DIFF
--- a/martian_packets/packets/tcp_craft.py
+++ b/martian_packets/packets/tcp_craft.py
@@ -62,7 +62,7 @@ class PacketConstructor:
         if self.validate_checksum(self.checksum) == True:
             checksum = self.checksum
         else:
-            checksum = self.calculate_checksum(pseudo_header + tcp_header + len(self.data))
+            checksum = self.calculate_checksum(pseudo_header + tcp_header + self.data)
 
         tcp_header = tcp_header[:16] + struct.pack('H', checksum) + tcp_header[18:]
         return tcp_header


### PR DESCRIPTION
Pass data, not len

Packet being sent at startup with payload when it should be a plain syn